### PR TITLE
fix to issue nr #7

### DIFF
--- a/lib/getUserMedia.js
+++ b/lib/getUserMedia.js
@@ -66,6 +66,14 @@
                         getUserMediaOptions.audio = true;
                         getUserMediaOptions.video = true;
                     }
+                    else if( options.video && !options.audio && optionStyle.object ){
+                        getUserMediaOptions = {};
+                        getUserMediaOptions.video = true;
+                    }
+                    else if( !options.video && options.audio && optionStyle.object ){
+                        getUserMediaOptions = {};
+                        getUserMediaOptions.audio = true;
+                    }
                     else if ( options.video && options.audio ) {
                         getUserMediaOptions = 'video, audio';
                     } else if ( options.video ) {


### PR DESCRIPTION
hi, this fixes (in a dirty way) https://github.com/addyosmani/getUserMedia.js/issues/7 but well, it's only a half fix, as another bug still persists. what's the other bug you ask?

well on Chrome Version 21.0.1180.79 you get asked to times if you want to allow stuff, the first time always for mic. and video, the other time as specified in the options (if you want audio chrome asks you for audio, if you want mic, chrome asks you for mic, if you want both, both)

if you could elaborate why you even need that "string syntax" options i could digg deeper into this topic (but well, i gues it would end in a complete new-write of the options detection meachanism) 
