### PR TITLE
complete  logic replacement of the object vs string style options

### DIFF
--- a/face-detection-demo/index.html
+++ b/face-detection-demo/index.html
@@ -51,7 +51,7 @@
 </div>
 
 <!--[if IE]><script src="js/excanvas.js"></script><![endif]-->
-<script type="text/javascript" src="../dist/getUserMedia.min.js"></script>
+<script type="text/javascript" src="../lib/getUserMedia.js"></script>
 <script type="text/javascript" src="js/glasses/ccv.js"></script>
 <script type="text/javascript" src="js/glasses/face.js"></script>
 <script type="text/javascript" src="js/glasses/stackblur.js"></script>

--- a/face-detection-demo/js/demo.js
+++ b/face-detection-demo/js/demo.js
@@ -66,7 +66,7 @@
 		// events that are triggered onCapture and onSave (for the fallback)
 		// and so on.
 		options: {
-			"audio": true,
+			"audio": false, //OTHERWISE FF nightlxy throws an NOT IMPLEMENTED error
 			"video": true,
 			el: "webcam",
 
@@ -117,9 +117,16 @@
 
 			if (App.options.context === 'webrtc') {
 
-				var video = App.options.videoEl,
-					vendorURL = window.URL || window.webkitURL;
-				video.src = vendorURL ? vendorURL.createObjectURL(stream) : stream;
+				var video = App.options.videoEl;
+				console.log(stream)
+        if ((typeof MediaStream !== "undefined" && MediaStream !== null) && stream instanceof MediaStream) {
+          console.log('mediastraeam')
+          video.src = stream;
+          return video.play();
+        } else {
+          var vendorURL = window.URL || window.webkitURL;
+          video.src = vendorURL ? vendorURL.createObjectURL(stream) : stream;
+        }
 
 				video.onerror = function () {
 					stream.stop();
@@ -134,7 +141,8 @@
 
 		deviceError: function (error) {
 			alert('No camera available.');
-			//console.error('An error occurred: [CODE ' + error.code + ']');
+			console.error('An error occurred: [CODE ' + error.code + ']');
+			console.error(error)
 		},
 
 		changeFilter: function () {

--- a/lib/getUserMedia.js
+++ b/lib/getUserMedia.js
@@ -1,4 +1,6 @@
-/*globals document:true, localStorage:true, navigator: true*/
+/*! getUserMedia - v0.6.0 - 2012-07-14
+* https://github.com/addyosmani/getUserMedia.js
+* Copyright (c) 2012 addyosmani; Licensed MIT */
 
 ;(function( window, document ) {
     "use strict";
@@ -29,12 +31,15 @@
                     video: true,
                     audio: true
                 }, nop);
-
+    			object = true
+				string = false 
             } catch (e) {
                 object = false;
                 try {
                     // Try string syntax
                     navigator.getUserMedia_("video, audio", nop);
+					string = true
+					object = false
                 } catch (e) { // Neither supported
                     string = false;
                 }
@@ -54,7 +59,7 @@
 
 
             var getUserMediaOptions, container, temp, video, ow, oh;
-
+            console.log(optionStyle)
             if ( !optionStyle.string && !optionStyle.object ) {
                 return undefined;
             }
@@ -65,6 +70,14 @@
                         getUserMediaOptions = {};
                         getUserMediaOptions.audio = true;
                         getUserMediaOptions.video = true;
+                    }
+                    else if( options.video && !options.audio && optionStyle.object ){
+                        getUserMediaOptions = {};
+                        getUserMediaOptions.video = true;
+                    }
+                    else if( !options.video && options.audio && optionStyle.object ){
+                        getUserMediaOptions = {};
+                        getUserMediaOptions.audio = true;
                     }
                     else if ( options.video && options.audio ) {
                         getUserMediaOptions = 'video, audio';
@@ -84,7 +97,7 @@
                     getUserMediaOptions.audio = true;
                 }
             }
-
+		    console.log(getUserMediaOptions)
             
 
             container = document.getElementById( options.el );
@@ -109,7 +122,8 @@
             // referenced for use in your applications
             options.videoEl = video;
             options.context = 'webrtc';
-
+		    console.log('calling')
+		    console.log(getUserMediaOptions)
             navigator.getUserMedia_(getUserMediaOptions, successCallback, errorCallback);
 
         } else {

--- a/lib/getUserMedia.js
+++ b/lib/getUserMedia.js
@@ -10,95 +10,25 @@
         // getUserMedia() feature detection
         navigator.getUserMedia_ = (navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia || navigator.msGetUserMedia);
 
-        // detect if {video: true} or "video" style options
-        // by creating an iframe and blowing it up
-        // style jacked from @kangax
-        // taken here from @miketaylr: //gist.github.com/f2ac64ed7fc467ccdfe3
-        var optionStyle = (function( win ) {
-
-            var el = document.createElement( 'iframe' ),
-                root = document.body || document.documentElement,
-                string = true,
-                object = true,
-                nop = function() {},
-                f;
-
-            root.appendChild(el);
-
-            try {
-                // Try spec (object) syntax
-                navigator.getUserMedia_({
-                    video: true,
-                    audio: true
-                }, nop);
-    			object = true
-				string = false 
-            } catch (e) {
-                object = false;
-                try {
-                    // Try string syntax
-                    navigator.getUserMedia_("video, audio", nop);
-					string = true
-					object = false
-                } catch (e) { // Neither supported
-                    string = false;
-                }
-            } finally { // Clean up
-                root.removeChild(el);
-                el = null;
-            }
-
-            return {
-                string: string,
-                object: object
-            };
-
-        }( window ));
-
         if ( !!navigator.getUserMedia_ ) {
 
 
             var getUserMediaOptions, container, temp, video, ow, oh;
-            console.log(optionStyle)
-            if ( !optionStyle.string && !optionStyle.object ) {
-                return undefined;
-            }
-
-            if (optionStyle.string) {
-                //canary latest
-                    if( options.video && options.audio && optionStyle.object ){
-                        getUserMediaOptions = {};
-                        getUserMediaOptions.audio = true;
-                        getUserMediaOptions.video = true;
-                    }
-                    else if( options.video && !options.audio && optionStyle.object ){
-                        getUserMediaOptions = {};
-                        getUserMediaOptions.video = true;
-                    }
-                    else if( !options.video && options.audio && optionStyle.object ){
-                        getUserMediaOptions = {};
-                        getUserMediaOptions.audio = true;
-                    }
-                    else if ( options.video && options.audio ) {
-                        getUserMediaOptions = 'video, audio';
-                    } else if ( options.video ) {
-                        getUserMediaOptions = 'video';
-                    } else if ( options.audio ) {
-                        getUserMediaOptions = 'audio';
-                    }
-            } else if ( optionStyle.object ) {
-
-                getUserMediaOptions = {};
-
-                if ( options.video ) {
-                    getUserMediaOptions.video = true;
-                }
-                if ( options.audio ) {
-                    getUserMediaOptions.audio = true;
-                }
-            }
-		    console.log(getUserMediaOptions)
             
+            //constructing an getUserMedia config-object and an string (we will try both)
+            var option_object = {};
+            var option_string = '';
+            if (options.video === true) {
+              option_object.video=true;
+              option_string='video'
+            }
+            if (options.audio === true) {
+              option_object.audio=true;
+              if (option_string != '') {
+                  option_string=option_string+', '
+              }
+              option_string = option_string+'audio'
+            }
 
             container = document.getElementById( options.el );
             temp = document.createElement('video');
@@ -122,10 +52,23 @@
             // referenced for use in your applications
             options.videoEl = video;
             options.context = 'webrtc';
-		    console.log('calling')
-		    console.log(getUserMediaOptions)
-            navigator.getUserMedia_(getUserMediaOptions, successCallback, errorCallback);
-
+            
+            //yeah, it's ugly but lets do it anyway
+            //first we try if getUserMedia supports the config object
+            try {
+              navigator.getUserMedia_(option_object, successCallback, errorCallback);
+            }
+            catch (e) {
+              try {
+                //if the config object failes, we try a config string
+                navigator.getUserMedia_(option_string, successCallback, errorCallback);
+              }
+              catch (e2)
+              {
+                //neither object nor string works
+                return undefined;
+              }
+            }
         } else {
             // Fallback to flash
             var source, el, cam;

--- a/lib/getUserMedia.js
+++ b/lib/getUserMedia.js
@@ -11,6 +11,7 @@
         navigator.getUserMedia_ = (navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia || navigator.msGetUserMedia);
 
         if ( !!navigator.getUserMedia_ ) {
+       //  if (false) { //test for flash
 
 
             var getUserMediaOptions, container, temp, video, ow, oh;
@@ -56,15 +57,23 @@
             //yeah, it's ugly but lets do it anyway
             //first we try if getUserMedia supports the config object
             try {
+              console.log('try object');
+              console.log(option_object);
               navigator.getUserMedia_(option_object, successCallback, errorCallback);
             }
             catch (e) {
+              console.log('option object failes');
+              console.log(e);
               try {
+                console.log('try string syntax')
+                console.log('option_string')
                 //if the config object failes, we try a config string
                 navigator.getUserMedia_(option_string, successCallback, errorCallback);
               }
               catch (e2)
               {
+                console.log('both failed')
+                console.log(e2)
                 //neither object nor string works
                 return undefined;
               }


### PR DESCRIPTION
as discussed in issue #10 this new logic just creates two configs, one as an object, the other one as a string. the upside is the there is now just one allowbar (issue +10 fixed) and #7 is fixed, too. 

tested it i google chrome  21.0.1180.79 and 23.0.1237.0 canary (all max os x lion), works so far, not tested on other browsers or plattforms. 

currently the fix is only in the /lib/getUserMedia.js, not in the /dist/ as i'm not quite sure how your build process works. 
