### PR TITLE
Typo in example code documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Below is a sample ```success``` callback taken from the demo application, where 
 
 ```javascript
 		success: function (stream) {
-			if (App.options.context === 'webrtc ') {
+			if (App.options.context === 'webrtc') {
 
 				var video = App.options.videoEl;
 				var vendorURL = window.URL || window.webkitURL;


### PR DESCRIPTION
there is a typo in the example code in the documentation.
There is a space next to 'webrtc' string that keeps failing the if. This space is not in the demo code.

``` javascript
if (App.options.context === 'webrtc ') {
                                   ^
```

should be 

``` javascript
if (App.options.context === 'webrtc') {
```
