### PR TITLE
Fixed flash fallback on Safari

### DIFF
--- a/lib/getUserMedia.js
+++ b/lib/getUserMedia.js
@@ -78,7 +78,16 @@
                     // Fallback to flash
                     var source, el, cam;
 
-                    source = '<object id="XwebcamXobjectX" classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000" type="application/x-shockwave-flash" data="' + options.swffile + '" width="' + options.width + '" height="' + options.height + '"><param name="movie" value="' + options.swffile + '" /><param name="FlashVars" value="mode=' + options.mode + '&amp;quality=' + options.quality + '" /><param name="allowScriptAccess" value="always" /></object>';
+                    source = '<!--[if IE]>'+
+                    '<object id="XwebcamXobjectX" classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" width="' + options.width + '" height="' + options.height + '">'+
+                    '<param name="movie" value="' + options.swffile + '" />'+
+                    '<![endif]-->'+
+                    '<!--[if !IE]>-->'+
+                    '<object id="XwebcamXobjectX" type="application/x-shockwave-flash" data="' + options.swffile + '" width="' + options.width + '" height="' + options.height + '">'+
+                    '<!--<![endif]-->'+
+                    '<param name="FlashVars" value="mode=' + options.mode + '&amp;quality=' + options.quality + '" />'+
+                    '<param name="allowScriptAccess" value="always" />'+
+                    '</object>';
                     el = document.getElementById(options.el);
                     el.innerHTML = source;
 


### PR DESCRIPTION
Flash object across browsers behave in different ways. Most notably IE uses ActiveX and require a "classid" and a "movie" param. See http://alistapart.com/article/flashembedcagematch for details.

Having classid as a field seems to break Safari compatibility so I added an 'if IE' conditional.

Haven't compiled the dist files and the html injection is in multiple lines. This is for ease of review; if the author thinks this PR is an appropriate solution then I'll put up a patch with compiled files and the works.

Further recommended changes that I can make if the author approves:
- adding alert that user doesn't have flash/a link to download flash
