### PR TITLE
updating README after Chrome Version 47 deprecated stream.stop()

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Below is a sample ```success``` callback taken from the demo application, where 
 				video.src = vendorURL ? vendorURL.createObjectURL(stream) : stream;
 
 				video.onerror = function () {
-					stream.stop();
+					stream.getVideoTracks90[0].stop();
 					streamError();
 				};
 


### PR DESCRIPTION
Fixes #51 
