### PR TITLE
these should be devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,14 +34,13 @@
     "node": "*"
   },
   "devDependencies": {
-    "grunt": "~0.4.5"
-  },
-  "keywords": ["getusermedia","webcam","video","gum"],
-  "dependencies": {
+    "grunt": "~0.4.5",
     "grunt-contrib-concat": "~0.5.0",
     "grunt-contrib-uglify": "~0.5.1",
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-contrib-connect": "~0.8.0"
-  }
+  },
+  "keywords": ["getusermedia","webcam","video","gum"],
+  "dependencies": {}
 }


### PR DESCRIPTION
consumers installing this package from npm shouldn't need these grunt contrib packages.